### PR TITLE
PYTHON env variable not set when building python

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -43,7 +43,7 @@ REM ========== bytecode compile standard library
 rd /s /q %STDLIB_DIR%\lib2to3\tests\
 if errorlevel 1 exit 1
 
-%PYTHON% -Wi %STDLIB_DIR%\compileall.py -f -q -x "bad_coding|badsyntax|py2_" %STDLIB_DIR%
+%PREFIX%\python.exe -Wi %STDLIB_DIR%\compileall.py -f -q -x "bad_coding|badsyntax|py2_" %STDLIB_DIR%
 if errorlevel 1 exit 1
 
 REM ========== add scripts
@@ -60,4 +60,4 @@ copy /Y %SRC_DIR%\Tools\scripts\2to3 %SCRIPTS%
 if errorlevel 1 exit 1
 
 REM ========== generate grammar files for 2to3
-%PYTHON% %SCRIPTS%\2to3 -l
+%PREFIX%\python.exe %SCRIPTS%\2to3 -l


### PR DESCRIPTION
Affects conda-build 2.1.10 and perhaps some previous versions. Anything after the merge of the fix for https://github.com/conda/conda-build/issues/1898.

See https://github.com/conda/conda-build/issues/1960 for details.